### PR TITLE
Update y8m-processor to handle a full directory of TFRecord files

### DIFF
--- a/data_pipeline/y8m-processor/.gitignore
+++ b/data_pipeline/y8m-processor/.gitignore
@@ -2,3 +2,4 @@
 .pytest_cache/*
 output/data/*.json
 output/logs/*.log
+.test

--- a/data_pipeline/y8m-processor/Makefile
+++ b/data_pipeline/y8m-processor/Makefile
@@ -16,11 +16,16 @@ build: .venv ## build requirements and virtual environment
 
 clean: ## Remove all installed dependences to start fresh
 	rm -rf .venv
+	rm .test
 
-test: .venv ## Run tests
+.test: $(SRC_FILES) .venv
 	.venv/bin/pytest
+	touch .test
 
-process: test ## Process a TFRecord file. Usage: make process TF_FILE=path/name.tfrecord
+test: .test ## Run tests
+	
+
+process: .test ## Process a TFRecord file. Usage: make process TF_FILE=path/name.tfrecord
 	@if [ -z "$(TF_FILE)" ]; then \
         echo "Error: Argument 'TF_FILE' is required."; \
         exit 1; \


### PR DESCRIPTION
Updates the y8m-processor script to accept two types of parameters: a single TFRecord file, or a directory containing TFRecord files. When passed a directory, it iterates over all TFRecord files within.